### PR TITLE
build change for windows platform to enable debug builds

### DIFF
--- a/packages/rar_fork/pubspec.yaml
+++ b/packages/rar_fork/pubspec.yaml
@@ -34,8 +34,8 @@ flutter:
         pluginClass: RarPlugin
       # linux:
       #   pluginClass: RarPlugin
-      # windows:
-      #   pluginClass: RarPluginCApi
+      windows:
+        pluginClass: RarPluginCApi
       # macOS uses UnrarKit via method channels (like iOS)
       macos:
         pluginClass: RarPlugin

--- a/packages/rar_fork/windows/CMakeLists.txt
+++ b/packages/rar_fork/windows/CMakeLists.txt
@@ -6,7 +6,16 @@ cmake_minimum_required(VERSION 3.14)
 
 # Project-level configuration.
 set(PROJECT_NAME "rar")
-project(${PROJECT_NAME} LANGUAGES CXX)
+project(${PROJECT_NAME} LANGUAGES CXX C)
+
+# Locate libarchive via vcpkg using VCPKG_ROOT environment variable.
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+endif()
+if(DEFINED ENV{VCPKG_ROOT})
+  set(LibArchive_ROOT "$ENV{VCPKG_ROOT}/installed/x64-windows")
+endif()
+find_package(LibArchive REQUIRED)
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.
@@ -20,6 +29,8 @@ set(PLUGIN_NAME "rar_plugin")
 list(APPEND PLUGIN_SOURCES
   "rar_plugin.cpp"
   "rar_plugin.h"
+  "../src/rar_native.c"
+  "../src/rar_native.h"
 )
 
 # Define the plugin library target. Its name must not be changed (see comment
@@ -40,21 +51,45 @@ apply_standard_settings(${PLUGIN_NAME})
 # exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
-target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL RAR_NATIVE_EXPORTS)
+if(MSVC)
+# silence C4244 errors
+set_source_files_properties("../src/rar_native.c" PROPERTIES COMPILE_FLAGS "/wd4244")
+endif()
 
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_include_directories(${PLUGIN_NAME} PRIVATE
+  ${LibArchive_INCLUDE_DIRS}
+  "${CMAKE_CURRENT_SOURCE_DIR}/../src")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin LibArchive::LibArchive)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an
 # external build triggered from this build file.
-set(rar_bundled_libraries
-  ""
-  PARENT_SCOPE
-)
+if(DEFINED ENV{VCPKG_ROOT})
+  # Determine vcpkg triplet architecture by void pointer size
+  # Triplet needs to be installed already through vcpkg
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_vcpkg_triplet "x64-windows")
+  else()
+    set(_vcpkg_triplet "x86-windows")
+  endif()
+
+  file(TO_CMAKE_PATH "$ENV{VCPKG_ROOT}/installed/${_vcpkg_triplet}/bin" _vcpkg_bin)
+  # Copy vcpkg dlls
+  file(GLOB _vcpkg_dlls "${_vcpkg_bin}/*.dll")
+
+  if(_vcpkg_dlls)
+    set(rar_bundled_libraries ${_vcpkg_dlls} PARENT_SCOPE)
+  else()
+    set(rar_bundled_libraries "" PARENT_SCOPE)
+  endif()
+else()
+  set(rar_bundled_libraries "" PARENT_SCOPE)
+endif()
 
 # === Tests ===
 # These unit tests can be run from a terminal after building the example, or

--- a/packages/rar_fork/windows/CMakeLists.txt
+++ b/packages/rar_fork/windows/CMakeLists.txt
@@ -60,7 +60,9 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL RAR_NATIVE_EXPORTS)
 if(MSVC)
-# silence C4244 errors
+# silence C4244 warnings
+# rar_native.c is assigning a 64-bit signed int to a 32-bit int on 64-bit platforms.
+# The variable is used for size, shouldn't matter unless it's over 2GB
 set_source_files_properties("../src/rar_native.c" PROPERTIES COMPILE_FLAGS "/wd4244")
 endif()
 

--- a/packages/rar_fork/windows/CMakeLists.txt
+++ b/packages/rar_fork/windows/CMakeLists.txt
@@ -13,7 +13,14 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 endif()
 if(DEFINED ENV{VCPKG_ROOT})
-  set(LibArchive_ROOT "$ENV{VCPKG_ROOT}/installed/x64-windows")
+  # Determine vcpkg triplet architecture by void pointer size
+  # Triplet needs to be installed already through vcpkg
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_vcpkg_triplet "x64-windows")
+  else()
+    set(_vcpkg_triplet "x86-windows")
+  endif()
+  set(LibArchive_ROOT "$ENV{VCPKG_ROOT}/installed/${_vcpkg_triplet}")
 endif()
 find_package(LibArchive REQUIRED)
 
@@ -70,14 +77,6 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin LibA
 # This list could contain prebuilt libraries, or libraries created by an
 # external build triggered from this build file.
 if(DEFINED ENV{VCPKG_ROOT})
-  # Determine vcpkg triplet architecture by void pointer size
-  # Triplet needs to be installed already through vcpkg
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(_vcpkg_triplet "x64-windows")
-  else()
-    set(_vcpkg_triplet "x86-windows")
-  endif()
-
   file(TO_CMAKE_PATH "$ENV{VCPKG_ROOT}/installed/${_vcpkg_triplet}/bin" _vcpkg_bin)
   # Copy vcpkg dlls
   file(GLOB _vcpkg_dlls "${_vcpkg_bin}/*.dll")

--- a/packages/rar_fork/windows/rar_plugin.cpp
+++ b/packages/rar_fork/windows/rar_plugin.cpp
@@ -1,17 +1,14 @@
 #include "rar_plugin.h"
 
-// This must be included before many other Windows headers.
 #include <windows.h>
-
-// For getPlatformVersion; remove unless needed for your plugin implementation.
-#include <VersionHelpers.h>
-
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
 #include <memory>
-#include <sstream>
+#include <string>
+
+#include "rar_native.h"
 
 namespace rar {
 
@@ -20,7 +17,7 @@ void RarPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows *registrar) {
   auto channel =
       std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-          registrar->messenger(), "rar",
+          registrar->messenger(), "com.lkrjangid.rar",
           &flutter::StandardMethodCodec::GetInstance());
 
   auto plugin = std::make_unique<RarPlugin>();
@@ -34,23 +31,129 @@ void RarPlugin::RegisterWithRegistrar(
 }
 
 RarPlugin::RarPlugin() {}
-
 RarPlugin::~RarPlugin() {}
 
 void RarPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  if (method_call.method_name().compare("getPlatformVersion") == 0) {
-    std::ostringstream version_stream;
-    version_stream << "Windows ";
-    if (IsWindows10OrGreater()) {
-      version_stream << "10+";
-    } else if (IsWindows8OrGreater()) {
-      version_stream << "8";
-    } else if (IsWindows7OrGreater()) {
-      version_stream << "7";
+
+  const auto &method = method_call.method_name();
+
+  if (method == "extractRarFile") {
+    const auto *args =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    if (!args) {
+      result->Error("INVALID_ARGS", "Expected map arguments");
+      return;
     }
-    result->Success(flutter::EncodableValue(version_stream.str()));
+
+    auto get_string = [&](const std::string &key) -> std::string {
+      auto it = args->find(flutter::EncodableValue(key));
+      if (it == args->end()) return {};
+      const auto *val = std::get_if<std::string>(&it->second);
+      return val ? *val : std::string{};
+    };
+
+    std::string rar_path = get_string("rarFilePath");
+    std::string dest_path = get_string("destinationPath");
+    std::string password = get_string("password");
+
+    if (rar_path.empty() || dest_path.empty()) {
+      result->Error("INVALID_ARGS", "rarFilePath and destinationPath required");
+      return;
+    }
+
+    int rc = rar_extract(
+        rar_path.c_str(),
+        dest_path.c_str(),
+        password.empty() ? nullptr : password.c_str(),
+        nullptr);
+
+    flutter::EncodableMap response;
+    if (rc == RAR_SUCCESS) {
+      response[flutter::EncodableValue("success")] =
+          flutter::EncodableValue(true);
+      response[flutter::EncodableValue("message")] =
+          flutter::EncodableValue(std::string("Extraction completed successfully"));
+    } else {
+      const char* emsg = rar_get_error_message(rc);
+      std::string msg = emsg ? emsg : "Unknown error";
+      response[flutter::EncodableValue("success")] =
+          flutter::EncodableValue(false);
+      response[flutter::EncodableValue("message")] =
+          flutter::EncodableValue(msg);
+    }
+    result->Success(flutter::EncodableValue(response));
+
+  } else if (method == "listRarContents") {
+    const auto *args =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    if (!args) {
+      result->Error("INVALID_ARGS", "Expected map arguments");
+      return;
+    }
+
+    auto get_string = [&](const std::string &key) -> std::string {
+      auto it = args->find(flutter::EncodableValue(key));
+      if (it == args->end()) return {};
+      const auto *val = std::get_if<std::string>(&it->second);
+      return val ? *val : std::string{};
+    };
+
+    std::string rar_path = get_string("rarFilePath");
+    std::string password = get_string("password");
+
+    if (rar_path.empty()) {
+      result->Error("INVALID_ARGS", "rarFilePath required");
+      return;
+    }
+
+    flutter::EncodableList files;
+
+    // rar_list uses a simple callback signature with no user-data pointer.
+    // This implementation assumes rar_list invokes callbacks synchronously on
+    // the calling thread. If callbacks may occur on other threads, the native API
+    // should be extended to accept a user-data pointer and this trampoline
+    // replaced with a context-based callback.
+    files.clear();
+    static thread_local flutter::EncodableList *tl_files = nullptr;
+    tl_files = &files;
+    int rc = rar_list(
+        rar_path.c_str(),
+        password.empty() ? nullptr : password.c_str(),
+        [](const char *name) {
+          if (tl_files && name)
+            tl_files->push_back(flutter::EncodableValue(std::string(name)));
+        },
+        nullptr);
+
+    flutter::EncodableMap response;
+    if (rc == RAR_SUCCESS) {
+      response[flutter::EncodableValue("success")] =
+          flutter::EncodableValue(true);
+      response[flutter::EncodableValue("message")] =
+          flutter::EncodableValue(std::string("Successfully listed RAR contents"));
+      response[flutter::EncodableValue("files")] =
+          flutter::EncodableValue(files);
+    } else {
+      response[flutter::EncodableValue("success")] =
+          flutter::EncodableValue(false);
+      response[flutter::EncodableValue("message")] =
+          flutter::EncodableValue(std::string(rar_get_error_message(rc)));
+      response[flutter::EncodableValue("files")] =
+          flutter::EncodableValue(flutter::EncodableList{});
+    }
+    result->Success(flutter::EncodableValue(response));
+
+  } else if (method == "createRarArchive") {
+    flutter::EncodableMap response;
+    response[flutter::EncodableValue("success")] =
+        flutter::EncodableValue(false);
+    response[flutter::EncodableValue("message")] =
+        flutter::EncodableValue(std::string(
+            "RAR creation is not supported. Consider using ZIP format instead."));
+    result->Success(flutter::EncodableValue(response));
+
   } else {
     result->NotImplemented();
   }

--- a/packages/rar_fork/windows/rar_plugin.cpp
+++ b/packages/rar_fork/windows/rar_plugin.cpp
@@ -1,5 +1,6 @@
 #include "rar_plugin.h"
 
+// This must be included before many other Windows headers.
 #include <windows.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>


### PR DESCRIPTION
## Summary
If you want this, here:

The rar_fork plugin didn't have a native implementation for windows (or linux still), so using the IDE directly to run/debug wouldn't work.  This removes access to flutter debugging tools and features like hot reload.  This adds support for building and debugging on the windows platform.

vcpkg must be installed, VCPKG_ROOT defined, and a triplet installed
ex: vcpkg install libarchive:x64-windows
also MSVC needs to be setup, but I think you need that just to get flutter/windows working

Suppressed C4244 because rar_native.c is assigning a 64-bit signed int to 32-bit int for sizes.  It shouldn't matter for this.

## Type of Change
- [X] Build/CI change

## Changes Made
- packages/rar_fork/pubspec.yaml - uncommented windows platform
- packages/rar_fork/windows/CMakeLists.txt - find VCPKG_ROOT/libarchive, detect the platform type for the triplet, set up compilation for rar_native.c, glob dlls.
- packages/rar_fork/windows/rar_plugin.cpp - remove getPlatformVersion stub, add extractRarFile, listRarContents, createRarArchive calls for rar_native.c

## Platform
- [X] Windows

## Testing

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. add a launch.json for vscode, or open app.dart
2. try debug/run in ide

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
