### PR TITLE
repo tidying - update gitignore and request for untracking some paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,6 @@ macos/Flutter/ephemeral
 ios/Flutter/Generated.xcconfig
 ios/Flutter/flutter_export_environment.sh
 ios/Flutter/ephemeral/
-# generated localizations, track arb only
-lib/l10n/app_localizations*.dart
 # Local package lock files
 packages/**/pubspec.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,21 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+# windows generated code
+windows/flutter/
+# linux generated code
+linux/flutter/
+# macos - needs some things tracked but not these
+macos/Flutter/GeneratedPluginRegistrant.swift
+macos/Flutter/ephemeral
+# ios - needs some things tracked but not these
+ios/Flutter/Generated.xcconfig
+ios/Flutter/flutter_export_environment.sh
+ios/Flutter/ephemeral/
+# generated localizations, track arb only
+lib/l10n/app_localizations*.dart
+# Local package lock files
+packages/**/pubspec.lock
 
 # Symbolication related
 app.*.symbols


### PR DESCRIPTION
## Summary
ignore some generated code paths for windows, linux, macos, ios, localizations, and package level pubspec.lock files

requires untracking these paths that are currently in the repo:

macos/Flutter/GeneratedPluginRegistrant.swift
linux/flutter/*
windows/flutter/*
packages/rar_fork/pubspec.lock

For the ios and mac paths, I am trusting google and can't verify, but the ios paths aren't in the repo currently.  The 1 macos file recommended to be removed appears to be auto generated by flutter.

For linux and windows, everything in their flutter paths is always regenerated on a flutter pub get/build.
The package level pubspec.lock files are usually recommended to be untracked as well, and just keep the app level one tracked.  Right now there's only the rar_lock one.

## Type of Change
- [X] Build/CI change

## Platform
- [X] All / Shared code

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
