### PR TITLE
Change series previews to use NextUp.  Change playback position for shorter items.

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -904,47 +904,26 @@ class _ContentRowsState extends State<_ContentRows>
       Map<String, dynamic> fallbackRawData = item.rawData;
 
       if (item.type == 'Series') {
-        final seasonsData = await client.itemsApi.getSeasons(item.id);
-        final seasons = (seasonsData['Items'] as List?)
-                ?.cast<Map<String, dynamic>>()
-                .toList() ??
-            const <Map<String, dynamic>>[];
-        if (seasons.isEmpty) {
-          return null;
-        }
-
-        seasons.sort((a, b) =>
-            ((a['IndexNumber'] as int?) ?? 1 << 20)
-                .compareTo((b['IndexNumber'] as int?) ?? 1 << 20));
-
-        final firstSeasonId = seasons.first['Id'] as String?;
-        if (firstSeasonId == null || firstSeasonId.isEmpty) {
-          return null;
-        }
-
-        final episodesData = await client.itemsApi.getEpisodes(
-          item.id,
-          seasonId: firstSeasonId,
+        // try NextUp to respect user progress, and avoid empty folder search
+        final nextUpData = await client.itemsApi.getNextUp(
+          seriesId: item.id,
+          limit: 1,
         );
-        final episodes = (episodesData['Items'] as List?)
-                ?.cast<Map<String, dynamic>>()
-                .toList() ??
-            const <Map<String, dynamic>>[];
-        if (episodes.isEmpty) {
-          return null;
+        final nextUpItems = (nextUpData['Items'] as List?)
+            ?.cast<Map<String, dynamic>>()
+            .toList();
+
+        if (nextUpItems != null && nextUpItems.isNotEmpty) {
+          final nextUp = nextUpItems.first;
+          // Skip specials (Season 0) if they appear in Next Up
+          if ((nextUp['ParentIndexNumber'] as int?) != 0) {
+            targetId = nextUp['Id'] as String;
+            fallbackRawData = nextUp;
+          }
         }
 
-        episodes.sort((a, b) =>
-            ((a['IndexNumber'] as int?) ?? 1 << 20)
-                .compareTo((b['IndexNumber'] as int?) ?? 1 << 20));
-
-        final first = episodes.first;
-        final firstId = first['Id'] as String?;
-        if (firstId == null || firstId.isEmpty) {
-          return null;
-        }
-        targetId = firstId;
-        fallbackRawData = first;
+        // If we still only have the Series ID, we couldn't find a valid episode
+        if (targetId == item.id) return null;
       }
 
       try {
@@ -970,6 +949,14 @@ class _ContentRowsState extends State<_ContentRows>
     final resume = _playbackPositionFromRaw(item);
     if (resume != null && resume > Duration.zero) {
       return resume;
+    }
+
+    final duration = item.runtime;
+    if (duration != null && duration > Duration.zero) {
+      // If the video is shorter than 15 minutes, start at 0 instead of 3 mins
+      if (duration < const Duration(minutes: 15)) {
+        return Duration.zero;
+      }
     }
 
     return const Duration(minutes: 3);


### PR DESCRIPTION
## Summary
Changes the series preview logic to use next up.  This lets jellyfin get the next episode itself and avoids empty folders and other problems.  Skips preview if nextup is going through specials.
Also change the start position for media that has a duration under 15 minutes.  They start at 0 now.

## Related Issues
Link related issues or tickets separated by commas.

- Fixes # #150 

## Type of Change
- [X] Bug fix
- [X] New feature

## Changes Made
Use nextup api to get the item for series preview.
Skip if the nextup item is in specials.
Change start position for <15m media to 0.

## Platform
- [X] All / Shared code

## Testing
android tv

- [X] Tested on physical device
- [X] Manual testing completed

### Test Steps
1. hover over series items that contains empty season folder that appears before current next up season items, and verify it plays.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
