### PR TITLE
build - add mobile-beta and androidtv-beta flavors to build.gradle.kts

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -62,29 +62,41 @@ android {
 
     flavorDimensions += "device"
     productFlavors {
+        val baseAppId = "org.moonfin.androidtv"
+        val baseAppName = "Moonfin"
+        val mobileAbis = listOf("arm64-v8a")
+        val tvAbis = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
         create("mobile") {
             dimension = "device"
-            applicationId = "org.moonfin.androidtv"
+            applicationId = baseAppId
             versionCode = flutter.versionCode
             versionName = flutter.versionName
-
-            ndk {
-                abiFilters += listOf("arm64-v8a")
-            }
+            ndk { abiFilters += mobileAbis }
+            manifestPlaceholders["appName"] = baseAppName
+        }
+        create("mobile-beta") {
+            dimension = "device"
+            applicationId = "$baseAppId.beta"
+            versionCode = flutter.versionCode
+            versionName = flutter.versionName
+            ndk { abiFilters += mobileAbis }
+            manifestPlaceholders["appName"] = "$baseAppName Beta"
         }
         create("androidTv") {
             dimension = "device"
-            applicationId = "org.moonfin.androidtv"
+            applicationId = baseAppId
             versionCode = androidTvVersionCode
             versionName = androidTvVersionName
-
-            ndk {
-                abiFilters += listOf(
-                    "arm64-v8a",
-                    "armeabi-v7a",
-                    "x86_64",
-                )
-            }
+            ndk { abiFilters += tvAbis }
+            manifestPlaceholders["appName"] = baseAppName
+        }
+        create("androidTv-beta") {
+            dimension = "device"
+            applicationId = "$baseAppId.beta"
+            versionCode = androidTvVersionCode
+            versionName = androidTvVersionName
+            ndk { abiFilters += tvAbis }
+            manifestPlaceholders["appName"] = "$baseAppName Beta"
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <uses-feature android:name="android.hardware.microphone" android:required="false"/>
     <uses-feature android:name="android.hardware.touchscreen" android:required="true"/>
     <application
-        android:label="Moonfin"
+        android:label="${appName}"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:enableOnBackInvokedCallback="true"


### PR DESCRIPTION
## Summary
added build flavors for mobile-beta and androidtv-beta to build.gradle.kts
those flavors change the app id to org.moonfin.androidtv.beta, and also the app name to Moonfin Beta.

## Type of Change
- [X] Build/CI change

## Changes Made
added build flavors to build.gradle.kts
changed androidmanifest.xml to allow a variable for the app label

## Platform
- [X] Android

## Testing
I used the androidtv-beta, I haven't tried normal, but I assume it's fine.

- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
