### PR TITLE
[Fix] Require pin when quick switching or logging in if required

### DIFF
--- a/lib/ui/screens/auth/login_screen.dart
+++ b/lib/ui/screens/auth/login_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
@@ -18,9 +19,11 @@ import '../../../auth/repositories/session_repository.dart';
 import '../../../data/services/media_server_client_factory.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/focus/dpad_keys.dart';
+import '../../../util/pin_code_util.dart';
 import '../../../util/platform_detection.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/login_scaffold.dart';
+import '../../widgets/pin_entry_dialog.dart';
 
 final _kAccent = AppColorScheme.accent;
 
@@ -345,7 +348,30 @@ class _LoginScreenState extends State<LoginScreen> {
             serverId: authResult.serverId,
             userId: authResult.userId,
           );
-          if (mounted) context.go(Destinations.home);
+          if (mounted) {
+            final store = GetIt.instance<PreferenceStore>();
+            final pinUtil = PinCodeUtil(store, authResult.userId);
+
+            if (pinUtil.isPinEnabled) {
+              final verified = await PinEntryDialog.show(
+                context,
+                mode: PinEntryMode.verify,
+                onVerify: pinUtil.verifyPin,
+                onForgotPin: () {
+                  if (mounted) context.go(Destinations.serverSelect);
+                },
+              );
+
+              if (!verified) {
+                // For quick connect, if PIN verification fails, go back to login screen
+                // to allow user to try with different credentials or method
+                if (mounted) context.go('${Destinations.login}?serverId=${_server!.id}');
+                return;
+              }
+            }
+
+            if (mounted) context.go(Destinations.home);
+          }
         }
       }
     } catch (_) {}
@@ -415,7 +441,26 @@ class _LoginScreenState extends State<LoginScreen> {
           );
           if (!mounted) return;
           if (switched) {
-            context.go(Destinations.home);
+            final store = GetIt.instance<PreferenceStore>();
+            final pinUtil = PinCodeUtil(store, result.userId);
+
+            if (pinUtil.isPinEnabled) {
+              final verified = await PinEntryDialog.show(
+                context,
+                mode: PinEntryMode.verify,
+                onVerify: pinUtil.verifyPin,
+                onForgotPin: () {
+                  if (mounted) context.go(Destinations.serverSelect);
+                },
+              );
+
+              if (!verified) {
+                if (mounted) context.go('${Destinations.login}?serverId=${_server!.id}');
+                return;
+              }
+            }
+
+            if (mounted) context.go(Destinations.home);
             return;
           }
           _finishLoginWithError(l10n.loginFailed);


### PR DESCRIPTION
# Pull Request

## Summary
Provide a brief description of what this PR changes and why.

## Related Issues
https://github.com/Moonfin-Client/Mobile-Desktop/issues/268

- Closes #
- Fixes #268
- Related to #

## Type of Change
- [X ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added pin check to login screen/quick switch screen
- 
- 

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch app
2. Login to profile with no pin
3. Quick switch to login requiring pin

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
